### PR TITLE
Fixed start:dev script crash on `blacklisted-address-ts` bot

### DIFF
--- a/blacklisted-address-ts/package.json
+++ b/blacklisted-address-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec \"npm run build && forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",


### PR DESCRIPTION
This PR fixes the crash that happens when running `npm start`