### PR TITLE
Fixed starter project npm script

### DIFF
--- a/blacklisted-address-ts/package.json
+++ b/blacklisted-address-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec \"npm run build && forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",

--- a/compound-ts/package.json
+++ b/compound-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec \"npm run build && forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "npm run build && forta-agent run --tx",
     "block": "npm run build && forta-agent run --block",

--- a/flash-loan-ts/package.json
+++ b/flash-loan-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec \"'npm run build && forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "npm run build && forta-agent run --tx",
     "block": "npm run build && forta-agent run --block",

--- a/high-gas-js/package.json
+++ b/high-gas-js/package.json
@@ -4,7 +4,7 @@
   "description": "Forta Agent that detects transactions with high gas used and high gas fee",
   "scripts": {
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,json --exec 'forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,json --exec \"forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",

--- a/high-gas-py/package.json
+++ b/high-gas-py/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "python3 -m pip install -r requirements_dev.txt",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e py --exec 'forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e py --exec \"forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",

--- a/high-volume-js/package.json
+++ b/high-volume-js/package.json
@@ -4,7 +4,7 @@
   "description": "Forta Agent that detects high volume of transactions from an address",
   "scripts": {
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,json --exec 'forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,json --exec \"forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",

--- a/minimum-balance-py/package.json
+++ b/minimum-balance-py/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "python3 -m pip install -r requirements_dev.txt",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e py --exec 'forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e py --exec \"forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",

--- a/minimum-balance-ts/package.json
+++ b/minimum-balance-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec \"npm run build && forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "npm run build && forta-agent run --tx",
     "block": "npm run build && forta-agent run --block",

--- a/poly-network-ts/package.json
+++ b/poly-network-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run start:dev",
-    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
+    "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec \"npm run build && forta-agent run\"",
     "start:prod": "forta-agent run --prod",
     "tx": "npm run build && forta-agent run --tx",
     "block": "npm run build && forta-agent run --block",


### PR DESCRIPTION
This PR fixes the `start:dev` script that causes bots crash 